### PR TITLE
Som/fix for mobile contextual menu positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wizdom-intranet/spfx-ui-fabric-vue",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "Office ui fabric components made specific for SPFx.",
   "main": "dist/bundle.esm.js",
   "module": "dist/index.js",

--- a/src/components/uiContextualMenu.vue
+++ b/src/components/uiContextualMenu.vue
@@ -24,7 +24,7 @@ export default {
                 // if contextmenu is out of window to the right - we change left to right orientation.
                 if(this.isOutOfViewport(contextualhost).right) {
                     contextualhost.style.left = "auto";
-                    contextualhost.style.right = "10px";
+                    contextualhost.style.right = 0;
                 }
             }
 
@@ -61,7 +61,7 @@ export default {
             out.top = bounding.top < 0;
             out.left = bounding.left < 0;
             out.bottom = bounding.bottom > (window.innerHeight || document.documentElement.clientHeight);
-            out.right = bounding.right > (window.innerWidth || document.documentElement.clientWidth);
+            out.right = bounding.right >= (window.innerWidth || document.documentElement.clientWidth);
             out.any = out.top || out.left || out.bottom || out.right;
             out.all = out.top && out.left && out.bottom && out.right;
 


### PR DESCRIPTION
The contextual menu on mobile devices or smaller viewport sizes was overflowing off-screen, this fixes that.