### PR TITLE
Noticeboard Contextual Menu Position

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wizdom-intranet/spfx-ui-fabric-vue",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Office ui fabric components made specific for SPFx.",
   "main": "dist/bundle.esm.js",
   "module": "dist/index.js",

--- a/src/components/uiContextualMenu.vue
+++ b/src/components/uiContextualMenu.vue
@@ -26,6 +26,8 @@ export default {
                     contextualhost.style.left = "auto";
                     contextualhost.style.right = 0;
                 }
+
+                contextualhost.style.position = "fixed";
             }
 
             // set scopeId for contextualhost


### PR DESCRIPTION
Addresses an issue occurring on mobile Chrome for iOS 14 devices were the (noticeboard item) contextual menu did not display when clicking on the three dots.

Work Item: 5901